### PR TITLE
Resource group into .env

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -148,3 +148,4 @@ module openAis 'core/ai/cognitiveservices.bicep' = [for (config, i) in items(ope
 }]
 
 output CONTAINER_APP_URL string =web.outputs.uri
+output RESOURCE_GROUP_NAME string =resourceGroup.name


### PR DESCRIPTION
This allows me to state in the docs to the reader to open their .env file in .azure folder and grab this value to use when setting up the PY Chat app for redeployment. 